### PR TITLE
List exclusions and ignored files

### DIFF
--- a/ArqRestoreCommand.m
+++ b/ArqRestoreCommand.m
@@ -48,6 +48,8 @@
 #import "GlacierRestorerParamSet.h"
 #import "GlacierRestorer.h"
 #import "S3AuthorizationProvider.h"
+#import "BucketExclude.h"
+#import "BucketExcludeSet.h"
 
 
 @implementation ArqRestoreCommand
@@ -339,7 +341,15 @@
     for (Bucket *bucket in buckets) {
         printf("\tfolder %s\n", [[bucket localPath] UTF8String]);
         printf("\t\tuuid %s\n", [[bucket bucketUUID] UTF8String]);
-        
+        printf("\t\texclusions\n");
+        for (BucketExclude *exclude in [bucket.bucketExcludeSet bucketExcludes]) {
+            printf("\t\t\t%s\n", [[exclude description] UTF8String]);
+        }
+        printf("\t\tignored paths\n");
+        NSArray *ignored = [bucket.ignoredRelativePaths.allObjects sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+        for (NSString *path in ignored) {
+            printf("\t\t\t%s\n", [path UTF8String]);
+        }
     }
     
     return YES;


### PR DESCRIPTION
This changes the `listfolders` command so it also lists exclusions and ignored paths for each folder. I needed this so I could recreate my Arq 3-era regular S3 folder as a Glacier-class backup.

The `description` does include some constants—I can make that more user-friendly if you like.

Do you need me to sign a CLA or anything? I'm happy to give up copyright on this contribution.

The output looks like this:

```
folder /Users/phil
    uuid 9D360FBF-E2FA-4BAC-98EA-0B3C1150D0DB
    exclusions
        <BucketExclude: type=kBucketExcludeTypeFileNameIs text=iOS DeviceSupport>
        <BucketExclude: type=kBucketExcludeTypeFileNameIs text=Saved Application State>
        <BucketExclude: type=kBucketExcludeTypeFileNameIs text=Caches>
    ignored paths
        /.android
        /.cabal
        /.emacs-autosaves297-Supernova.local~
        /.emacs-autosaves3104-Supernova.local~
        /.emacs-autosaves34359-Supernova.local~
        /.gem
        /.ghc
        /.gradle
        /.rbenv
        /.Trash
        /.Trashes
```
