### PR TITLE
Fix the build to work on 2025-08-01 macOS 15 openssl 3

### DIFF
--- a/build.md
+++ b/build.md
@@ -1,0 +1,93 @@
+# Build Instructions for `arq_restore` with Modern Tools
+
+This document describes how to build `arq_restore`, verified with [anthonywu's](https://github.com/anthonywu) setup:
+
+- macOS Sequoia 15.5
+- Apple Silicon M1
+- Xcode 16.4
+- OpenSSL 3.x installed via `nix-env -iA nixpkgs.openssl`
+- on date: 2025-08-01
+
+## Fixes Applied
+
+The commit prior to the 2025-08-01 build fix was:
+
+```
+commit d4a3d0e14c51695fb0e38c78804859a856eca3bc (HEAD -> master, up/master, up/HEAD)
+Author: Stefan Reitshamer <stefan@reitshamer.com>
+Date:   Mon Dec 14 17:25:04 2020 -0500
+```
+
+The following fixes were applied to make the code compile with modern tools, almost 5 years later.
+
+### 1. C Language Compatibility (lz4.c)
+- Fixed function prototypes that were missing `void` parameter lists
+- Changed `int LZ4_sizeofState()` to `int LZ4_sizeofState(void)`
+- Changed `int LZ4_sizeofStreamState()` to `int LZ4_sizeofStreamState(void)`
+
+### 2. HTTP Header Conflicts (HTTP.h)
+- Added header guards to prevent macro redefinition errors
+- Wrapped HTTP status code definitions with `#ifndef` checks
+
+### 3. OpenSSL 3.x API Updates (OpenSSLCryptoKey.m)
+- Changed `EVP_CIPHER_CTX` from stack allocation to heap allocation
+- Replaced `EVP_CIPHER_CTX_init()` with `EVP_CIPHER_CTX_new()`
+- Replaced `EVP_CIPHER_CTX_cleanup()` with `EVP_CIPHER_CTX_free()`
+- Updated all references from `&cipherContext` to `cipherContext` (pointer)
+
+## Building
+
+The `/nix/store/...` paths are for example only.
+
+These paths will be different depending on which system/day/version your dependencies come from.
+
+You also may install `openssl` via different package managers. It's up to you to tweak the recipe here to work for you.
+
+In my case, I build for arm64 architecture:
+
+```bash
+xcodebuild build -configuration Release \
+  ARCHS=arm64 \
+  VALID_ARCHS=arm64 \
+  ONLY_ACTIVE_ARCH=NO \
+  HEADER_SEARCH_PATHS='$(inherited) /nix/store/vg95s0pj6mni9xrcmsnp2rg44kqpxyic-openssl-3.0.16-dev/include' \
+  LIBRARY_SEARCH_PATHS='$(inherited) /nix/store/8gl0j1qfbn0jlr1d67fr2pkk8gpxk43b-openssl-3.0.16/lib'
+```
+
+Note: The exact nix store paths may vary. Find your OpenSSL paths with:
+```bash
+find /nix/store -name "openssl" -type d -path "*include*" | grep -E "openssl-3.*include"
+find /nix/store -name "libcrypto*.dylib" -o -name "libssl*.dylib" | grep -E "openssl-3"
+```
+
+## Output
+
+The built executable will be at: `build/Release/arq_restore`
+
+## Testing
+
+Test the executable:
+
+```bash
+./build/Release/arq_restore
+```
+
+This should display the usage help:
+
+```
+Usage:
+	arq_restore [-l loglevel] listtargets
+	arq_restore [-l loglevel] addtarget <nickname> aws <access_key>
+	arq_restore [-l loglevel] addtarget <nickname> local <path>
+	arq_restore [-l loglevel] deletetarget <nickname>
+
+	arq_restore [-l loglevel] listcomputers <target_nickname>
+	arq_restore [-l loglevel] listfolders <target_nickname> <computer_uuid>
+	arq_restore [-l loglevel] printplist <target_nickname> <computer_uuid> <folder_uuid>
+	arq_restore [-l loglevel] listtree <target_nickname> <computer_uuid> <folder_uuid>
+	arq_restore [-l loglevel] restore <target_nickname> <computer_uuid> <folder_uuid> [relative_path]
+	arq_restore [-l loglevel] clearcache <target_nickname>
+
+log levels: none, error, warn, info, and debug
+log output: ~/Library/Logs/arq_restorer
+```

--- a/cocoastack/crypto/OpenSSLCryptoKey.m
+++ b/cocoastack/crypto/OpenSSLCryptoKey.m
@@ -141,32 +141,35 @@
         return YES;
     }
     
-    EVP_CIPHER_CTX cipherContext;
-    EVP_CIPHER_CTX_init(&cipherContext);
-    if (!EVP_EncryptInit(&cipherContext, cipher, evpKey, iv)) {
+    EVP_CIPHER_CTX *cipherContext = EVP_CIPHER_CTX_new();
+    if (!cipherContext) {
+        SETNSERROR([CryptoKey errorDomain], -1, @"EVP_CIPHER_CTX_new failed");
+        return NO;
+    }
+    if (!EVP_EncryptInit(cipherContext, cipher, evpKey, iv)) {
         SETNSERROR([CryptoKey errorDomain], -1, @"EVP_EncryptInit: %@", [OpenSSL errorMessage]);
-        EVP_CIPHER_CTX_cleanup(&cipherContext);
+        EVP_CIPHER_CTX_free(cipherContext);
         return NO;
     }
     
     // Need room for data + cipher block size - 1.
-    [theOutBuffer setLength:([plainData length] + EVP_CIPHER_CTX_block_size(&cipherContext))];
+    [theOutBuffer setLength:([plainData length] + EVP_CIPHER_CTX_block_size(cipherContext))];
     unsigned char *outbuf = (unsigned char *)[theOutBuffer mutableBytes];
     
     int outlen = 0;
-    if (!EVP_EncryptUpdate(&cipherContext, outbuf, &outlen, [plainData bytes], (int)[plainData length])) {
+    if (!EVP_EncryptUpdate(cipherContext, outbuf, &outlen, [plainData bytes], (int)[plainData length])) {
         SETNSERROR([CryptoKey errorDomain], -1, @"EVP_EncryptUpdate: %@",  [OpenSSL errorMessage]);
-        EVP_CIPHER_CTX_cleanup(&cipherContext);
+        EVP_CIPHER_CTX_free(cipherContext);
         return NO;
     }
     
     int extralen = 0;
-    if (!EVP_EncryptFinal(&cipherContext, outbuf + outlen, &extralen)) {
+    if (!EVP_EncryptFinal(cipherContext, outbuf + outlen, &extralen)) {
         SETNSERROR([CryptoKey errorDomain], -1, @"EVP_EncryptFinal: %@",  [OpenSSL errorMessage]);
-        EVP_CIPHER_CTX_cleanup(&cipherContext);
+        EVP_CIPHER_CTX_free(cipherContext);
         return NO;
     }
-    EVP_CIPHER_CTX_cleanup(&cipherContext);
+    EVP_CIPHER_CTX_free(cipherContext);
     
     [theOutBuffer setLength:(outlen + extralen)];
     return YES;
@@ -191,31 +194,34 @@
     int inlen = (int)[encrypted length];
     unsigned char *input = (unsigned char *)[encrypted bytes];
     
-    EVP_CIPHER_CTX cipherContext;
-    EVP_CIPHER_CTX_init(&cipherContext);
-    if (!EVP_DecryptInit(&cipherContext, cipher, evpKey, iv)) {
+    EVP_CIPHER_CTX *cipherContext = EVP_CIPHER_CTX_new();
+    if (!cipherContext) {
+        SETNSERROR([CryptoKey errorDomain], -1, @"EVP_CIPHER_CTX_new failed");
+        return NO;
+    }
+    if (!EVP_DecryptInit(cipherContext, cipher, evpKey, iv)) {
         SETNSERROR([CryptoKey errorDomain], -1, @"EVP_DecryptInit: %@", [OpenSSL errorMessage]);
-        EVP_CIPHER_CTX_cleanup(&cipherContext);
+        EVP_CIPHER_CTX_free(cipherContext);
         return NO;
     }
     
-    [theOutBuffer setLength:(inlen + EVP_CIPHER_CTX_block_size(&cipherContext))];
+    [theOutBuffer setLength:(inlen + EVP_CIPHER_CTX_block_size(cipherContext))];
     unsigned char *outbuf = (unsigned char *)[theOutBuffer mutableBytes];
     int outlen = 0;
-    if (!EVP_DecryptUpdate(&cipherContext, outbuf, &outlen, input, inlen)) {
+    if (!EVP_DecryptUpdate(cipherContext, outbuf, &outlen, input, inlen)) {
         SETNSERROR([CryptoKey errorDomain], -1, @"EVP_DecryptUpdate: %@", [OpenSSL errorMessage]);
-        EVP_CIPHER_CTX_cleanup(&cipherContext);
+        EVP_CIPHER_CTX_free(cipherContext);
         return NO;
     }
     
     int extralen = 0;
-    if (!EVP_DecryptFinal(&cipherContext, outbuf + outlen, &extralen)) {
+    if (!EVP_DecryptFinal(cipherContext, outbuf + outlen, &extralen)) {
         SETNSERROR([CryptoKey errorDomain], -1, @"EVP_DecryptFinal: %@", [OpenSSL errorMessage]);
-        EVP_CIPHER_CTX_cleanup(&cipherContext);
+        EVP_CIPHER_CTX_free(cipherContext);
         return NO;
     }
     
-    EVP_CIPHER_CTX_cleanup(&cipherContext);
+    EVP_CIPHER_CTX_free(cipherContext);
     [theOutBuffer setLength:(outlen + extralen)];
     return YES;
 }

--- a/cocoastack/http/HTTP.h
+++ b/cocoastack/http/HTTP.h
@@ -31,21 +31,48 @@
  */
 
 
+#ifndef ARQ_HTTP_H
+#define ARQ_HTTP_H
 
-
+#ifndef HTTP_1_1
 #define HTTP_1_1 @"1.1"
+#endif
+#ifndef HTTP_OK
 #define HTTP_OK (200)
+#endif
+#ifndef HTTP_NO_CONTENT
 #define HTTP_NO_CONTENT (204)
+#endif
 #define HTTP_INTERNAL_SERVER_ERROR (500)
+#ifndef HTTP_FORBIDDEN
 #define HTTP_FORBIDDEN (403)
+#endif
+#ifndef HTTP_BAD_REQUEST
 #define HTTP_BAD_REQUEST (400)
+#endif
+#ifndef HTTP_METHOD_NOT_ALLOWED
 #define HTTP_METHOD_NOT_ALLOWED (405)
+#endif
+#ifndef HTTP_REQUEST_TIMEOUT
 #define HTTP_REQUEST_TIMEOUT (408)
+#endif
+#ifndef HTTP_CONFLICT
 #define HTTP_CONFLICT (409)
+#endif
 #define HTTP_REQUESTED_RANGE_NOT_SATISFIABLE (416)
+#ifndef HTTP_LENGTH_REQUIRED
 #define HTTP_LENGTH_REQUIRED (411)
+#endif
+#ifndef HTTP_NOT_FOUND
 #define HTTP_NOT_FOUND (404)
+#endif
+#ifndef HTTP_MOVED_PERMANENTLY
 #define HTTP_MOVED_PERMANENTLY (301)
+#endif
+#ifndef HTTP_MOVED_TEMPORARILY
 #define HTTP_MOVED_TEMPORARILY (307)
+#endif
 #define HTTP_SERVICE_NOT_AVAILABLE (503)
 #define HTTP_VERSION_NOT_SUPPORTED (505)
+
+#endif /* ARQ_HTTP_H */

--- a/cocoastack/shared/lz4.c
+++ b/cocoastack/shared/lz4.c
@@ -370,7 +370,7 @@ typedef enum { full = 0, partial = 1 } earlyEnd_directive;
 **************************************/
 int LZ4_versionNumber (void) { return LZ4_VERSION_NUMBER; }
 int LZ4_compressBound(int isize)  { return LZ4_COMPRESSBOUND(isize); }
-int LZ4_sizeofState() { return LZ4_STREAMSIZE; }
+int LZ4_sizeofState(void) { return LZ4_STREAMSIZE; }
 
 
 
@@ -1471,7 +1471,7 @@ int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize,
 
 /* Obsolete Streaming functions */
 
-int LZ4_sizeofStreamState() { return LZ4_STREAMSIZE; }
+int LZ4_sizeofStreamState(void) { return LZ4_STREAMSIZE; }
 
 static void LZ4_init(LZ4_stream_t_internal* lz4ds, BYTE* base)
 {


### PR DESCRIPTION
The restore script was developed in 2017 and isn't actively maintained. I have low confidence this tool actually works if we need it in an emergency and the Arq GUI and support goes away.

I try to modernize the build here, but the arq_restore CLI also needs more documentation and examples.

Hopefully your team can provide some rich examples and restoration workflows.