### PR TITLE
Refactor to side-effect free assertion

### DIFF
--- a/cocoastack/shared/ExePath.m
+++ b/cocoastack/shared/ExePath.m
@@ -38,7 +38,8 @@
     uint32_t exePathSize = 0;
     _NSGetExecutablePath(NULL, &exePathSize);
     char *exePath = (char *)malloc(exePathSize);
-    NSAssert(_NSGetExecutablePath(exePath, &exePathSize) == 0, @"must be zero");
+    int result = _NSGetExecutablePath(exePath, &exePathSize);
+    NSAssert(result == 0, @"must be zero");
     NSString *ret = [[NSString alloc] initWithBytes:exePath length:exePathSize encoding:NSUTF8StringEncoding];
     free(exePath);
     return ret;


### PR DESCRIPTION
Assertions should not have side-effects as this would change runtime behaviour when code is compiled with assertions disabled.

In this specific case, `arq_restore` fails to access its own executable path when assertions are disabled. The memory buffer remains uninitialised. This causes problems downstream in the code with keychain items not being created.